### PR TITLE
Segregation of data related ops from solely file relate ops

### DIFF
--- a/include/ConsoleOps.hpp
+++ b/include/ConsoleOps.hpp
@@ -1,0 +1,47 @@
+#ifndef CONSOLE_OPS_HPP
+#define CONSOLE_OPS_HPP
+
+#include "DataOps.hpp"
+
+#include <iostream>
+#include <string_view>
+
+using DataQ = std::queue<std::pair<std::string, std::string>>;
+
+class ConsoleOps : public DataOps
+{
+    public:
+        enum class LoggingTypes
+        {
+            ERROR_LOG,
+            INFO_LOG,
+            DEBUG_LOG,
+            DEFAULT_LOG
+        };
+
+        static std::vector<std::pair<const std::string_view, const LoggingTypes>> 
+            LoggingTypesEnumStringMap;
+
+        ConsoleOps();
+        ~ConsoleOps();
+        ConsoleOps(const ConsoleOps& rhs) = delete;
+        ConsoleOps(ConsoleOps&& rhs) = delete;
+        ConsoleOps& operator=(const ConsoleOps& rhs) = delete;
+        ConsoleOps& operator=(ConsoleOps&& rhs) = delete;
+
+        void flush();
+        void writeToConsole();
+
+        static ConsoleOps::LoggingTypes loggingTypesStringToEnum(const std::string_view enumString) noexcept;
+        static std::string loggingTypesEnumToString(const ConsoleOps::LoggingTypes& loggingType) noexcept;
+
+    protected:
+        void writeToOutStreamObject(BufferQ&& dataQueue, std::exception_ptr& excpPtr) override;
+
+    private:
+        std::mutex m_mtx;
+        std::condition_variable m_cv;
+        std::atomic_bool m_isOpsRunning;
+};
+
+#endif  //CONSOLE_OPS_HPP

--- a/include/DataOps.hpp
+++ b/include/DataOps.hpp
@@ -1,0 +1,149 @@
+/**
+ * @file DataOps.hpp
+ * @brief Declaration of the DataOps class for thread-safe data queue operations.
+ *
+ * @copyright
+ * MIT License
+ * 
+ * Copyright (c) 2024 Swarnendu RC
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef DATA_OPS_HPP
+#define DATA_OPS_HPP
+
+#include <queue>
+#include <vector>
+#include <array>
+#include <mutex>
+#include <thread>
+#include <atomic>
+#include <exception>
+
+using BufferQ = std::queue<std::array<char, 1025>>;
+
+class DataOps
+{
+    public:
+        /**
+         * @brief Get all the exceptions happened during the file ops
+         *
+         * @return std::filesystem::path The file path object
+         */
+        inline const std::vector<std::exception_ptr>& getAllExceptions() noexcept       { return m_excpPtrVec; }
+
+        /**
+         * @brief Add a raised exception to the exception vector
+         *
+         * @param [in] excpPtr The exception pointer to be added
+         * @note This function is thread safe. It uses mutex to ensure that
+         * only one thread can add an exception at a time.
+         */
+        inline void addRaisedException(const std::exception_ptr& excpPtr) noexcept      { m_excpPtrVec.emplace_back(excpPtr); }
+
+        /**
+         * @brief Default constructor for DataOps class
+         * Initializes the data records queue, data ready flag,
+         * shutdown and exit flag, and starts the watcher thread
+         *
+         * @note The watcher thread will keep watch and pull the data
+         * from the data records queue and write it to the file
+         * whenever it is available.
+         * @note This function is thread safe. It uses mutex and condition variable
+         * to ensure that only one thread can keep watch and pull the data at a time.
+         */
+        DataOps();
+
+        /**
+         * @brief Destructor for DataOps class
+         * Stops the watcher thread and clears the data records queue
+         *
+         * @note This function is thread safe. It uses mutex and condition variable
+         * to ensure that only one thread can stop the watcher thread and clear the data records queue at a time.
+         */
+        virtual ~DataOps();
+
+        /**
+         * @brief Deleted copy constructor and move constructor
+         * to prevent copying and moving of DataOps objects
+         */
+        DataOps(const DataOps& rhs) = delete;
+        DataOps(DataOps&& rhs) = delete;
+        DataOps& operator=(const DataOps& rhs) = delete;
+        DataOps& operator=(DataOps&& rhs) = delete;
+
+    protected:
+        /**
+         * @brief Keep watch and pull the data from the data records queue
+         *
+         * @note This function is thread safe. It uses mutex and condition variable
+         * to ensure that only one thread can keep watch and pull the data at a time.
+         *
+         * @see writeToFile
+         * @see pop
+         * @see push
+         */
+        void keepWatchAndPull();
+
+        /**
+         * @brief Write to the file
+         *
+         * @param [in] dataQueue The data queue to be written to the file
+         * @param [out] excpPtr The exception pointer to be used for exception handling
+         *
+         * @note This function is thread safe. It uses mutex and condition variable
+         * to ensure that only one thread can write to the outstream object at a time.
+         */
+        virtual void writeToOutStreamObject(BufferQ&& /*dataQueue*/, std::exception_ptr& /*excpPtr*/) {}
+
+        /**
+         * @brief Pops the data to a data buffer
+         *
+         * @param [out] data The data to be popped from the data records queue
+         * @return true If the data was popped successfully, otherwise
+         * @return false
+         */
+        bool pop(BufferQ& data);
+
+        /**
+         * @brief Push the data to the data records queue
+         *
+         * @param [in] data The data to be pushed to the data records queue
+         * @note This function is thread safe. It uses mutex and condition variable
+         * to ensure that only one thread can push the data at a time.
+         */
+        void push(const std::string_view data);
+
+        BufferQ m_DataRecords;
+        std::mutex m_DataRecordsMtx;
+        std::condition_variable m_DataRecordsCv;
+        std::atomic_bool m_dataReady;
+        std::atomic_bool m_shutAndExit;
+        std::thread m_watcher;
+
+        /**
+         * @brief It is a vector of exception pointers
+         * which is used to store the exceptions occurred
+         * during the data operations.
+         */
+        std::vector<std::exception_ptr> m_excpPtrVec;
+};
+
+#endif  //DATA_OPS_HPP

--- a/src/ConsoleOps.cpp
+++ b/src/ConsoleOps.cpp
@@ -1,0 +1,74 @@
+#include "ConsoleOps.hpp"
+
+std::vector<std::pair<const std::string_view, const ConsoleOps::LoggingTypes>> 
+    ConsoleOps::LoggingTypesEnumStringMap = 
+        {   std::make_pair("ERROR_LOG", LoggingTypes::ERROR_LOG),
+            std::make_pair("INFO_LOG", LoggingTypes::INFO_LOG),
+            std::make_pair("DEBUG_LOG", LoggingTypes::DEBUG_LOG),
+            std::make_pair("DEFAULT_LOG", LoggingTypes::DEFAULT_LOG) 
+        };
+
+/*static*/ConsoleOps::LoggingTypes ConsoleOps::loggingTypesStringToEnum(const std::string_view enumString) noexcept
+{
+    auto retVal = LoggingTypes::DEBUG_LOG;
+    if (!enumString.empty())
+    {
+        std::string enumStringCopy;
+        for (auto stringChar : enumString)
+            enumStringCopy += std::toupper(stringChar);
+
+        for (const auto& pair : LoggingTypesEnumStringMap)
+        {
+            if (!pair.first.compare(enumStringCopy))
+            {
+                retVal = pair.second;
+                break;
+            }
+        }
+    }
+    return retVal;
+}
+
+/*static*/ std::string ConsoleOps::loggingTypesEnumToString(const ConsoleOps::LoggingTypes& loggingType) noexcept
+{
+    auto retVal = std::string();
+    for (const auto& pair : LoggingTypesEnumStringMap)
+    {
+        if (pair.second == loggingType)
+        {
+            retVal = pair.first;
+            break;
+        }
+    }
+    return retVal;
+}
+
+ConsoleOps::ConsoleOps()
+    : DataOps()
+    , m_isOpsRunning(false)
+{}
+
+ConsoleOps::~ConsoleOps()
+{
+    {
+        std::lock_guard<std::mutex> lock(m_mtx);
+    }
+    m_shutAndExit = true;
+    m_cv.notify_all();
+}
+
+void ConsoleOps::writeToOutStreamObject(BufferQ&& dataQueue, std::exception_ptr& excpPtr)
+{
+    if (dataQueue.empty())
+        return;
+
+    try
+    {
+        // Place holder for now
+    }
+    catch(...)
+    {
+        excpPtr = std::current_exception();
+    }
+}
+

--- a/src/DataOps.cpp
+++ b/src/DataOps.cpp
@@ -1,0 +1,153 @@
+/*
+ * MIT License
+ * 
+ * Copyright (c) 2024 Swarnendu RC
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * 
+ * File: DataOps.cpp
+ * Description: Implementation of the DataOps class for asynchronous data operations.
+ * See DataOps.hpp for class definition and documentation.
+ */
+
+#include "DataOps.hpp"
+
+///*static*/std::vector<std::exception_ptr> DataOps::m_excpPtrVec = {0};
+
+DataOps::DataOps()
+    : m_DataRecords()
+    , m_dataReady(false)
+    , m_shutAndExit(false)
+    , m_excpPtrVec(0)
+{
+}
+
+/*virtual*/DataOps::~DataOps()
+{
+    // Wait for any ongoing data operations to finish
+    std::unique_lock<std::mutex> dataLock(m_DataRecordsMtx);
+    // Set the flag to true to indicate that we are shutting down
+    m_shutAndExit = true;
+    // Notify the watcher thread to wake up and complete
+    // any pending operations before exiting
+    dataLock.unlock();
+    m_DataRecordsCv.notify_one();
+
+    if (m_watcher.joinable())
+        m_watcher.join();
+}
+
+void DataOps::push(const std::string_view data)
+{
+    if (data.empty())
+        return;
+
+    auto push = [this](std::array<char, 1025>& dataRecord, const std::string_view data)
+    {
+        std::copy(data.begin(), data.end(), dataRecord.begin());
+        if (data.size() < dataRecord.size())
+        {
+            auto dataSize = data.size();
+            std::fill(dataRecord.begin() + dataSize, dataRecord.end(), '\0');
+        }
+        m_DataRecords.push(dataRecord);
+    };
+    
+    {
+        std::array<char, 1025> dataRecord; // One extra byte for null termination
+        std::scoped_lock<std::mutex> lock(m_DataRecordsMtx);
+        if (data.size() > dataRecord.size())
+        {
+            std::string dataCopy = data.data();
+            while (dataCopy.size() > dataRecord.size()) // Split the data into 1024 byte chunks
+            {
+                push(dataRecord, dataCopy.substr(0, dataRecord.size() - 1));
+                dataRecord.fill('\0');
+                dataCopy = dataCopy.substr(dataRecord.size());
+            }
+            if (!dataCopy.empty())
+            {
+                push(dataRecord, dataCopy);
+            }
+        }
+        else
+        {
+            push(dataRecord, data);
+        }
+    }
+    // If the data queue contains at least 256 elements
+    // then notify the watcher thread that data is available
+    // and it can start writing to the file
+    if (m_DataRecords.size() == 256)
+    {
+        m_dataReady = true;
+        m_DataRecordsCv.notify_one();
+    }
+}
+
+bool DataOps::pop(BufferQ& data)
+{
+    if (m_DataRecords.empty())
+        return false;
+
+    // Clear the outgoing data buffer
+    BufferQ().swap(data);
+    data.swap(m_DataRecords);
+    m_dataReady = false;
+
+    return true;
+}
+
+void DataOps::keepWatchAndPull()
+{
+    BufferQ dataq;
+    // It is an infinite loop, but it will break out of the loop
+    // when the m_shutAndExit flag is set to true
+    do
+    {
+        std::unique_lock<std::mutex> dataLock(m_DataRecordsMtx);
+        m_DataRecordsCv.wait(dataLock, [this]{ return m_dataReady || m_shutAndExit.load(); });
+
+        auto success = pop(dataq);
+        dataLock.unlock();
+        m_DataRecordsCv.notify_one();
+        // Spawn a thread to write to the file
+        // and pass the data queue to it so that
+        // the data records queue can be free for
+        // other threads to push data to it
+        // and the file can be written to in parallel
+        // The thread will be joined after the file is written
+        std::thread writerThread;
+        std::exception_ptr excpPtr = nullptr;
+        if (success)
+        {
+            writerThread = std::thread([this, &dataq, &excpPtr](){ writeToOutStreamObject(std::move(dataq), excpPtr); });
+        }
+        if (writerThread.joinable())
+        {
+            if (excpPtr)
+                m_excpPtrVec.emplace_back(excpPtr);
+            writerThread.join();
+        }
+
+        if (m_shutAndExit)
+            break;
+    } while (true);
+}
+

--- a/tests/ConsoleOpsTest.cpp
+++ b/tests/ConsoleOpsTest.cpp
@@ -1,0 +1,27 @@
+//leaks --atExit --list -- ./bin/TestLogger_d --gtest_shuffle --gtest_repeat=3 --gtest_filter="ConsoleOpsTest.*"
+//leaks --atExit --list -- ./bin/TestLogger_d --gtest_shuffle --gtest_repeat=3 --gtest_filter=ConsoleOpsTest.testloggingTypesStringToEnumAndEnumToString
+
+#include "ConsoleOps.hpp"
+
+#include <gtest/gtest.h>
+
+class ConsoleOpsTest : public ::testing::Test
+{
+};
+
+TEST_F(ConsoleOpsTest, testloggingTypesStringToEnumAndEnumToString)
+{
+    std::vector<std::string> enumStringsVec = { "ERROR_LOG", "INFO_LOG", "DEBUG_LOG", "DEFAULT_LOG" };
+    std::vector<ConsoleOps::LoggingTypes> enumsVec = {
+        ConsoleOps::LoggingTypes::ERROR_LOG,
+        ConsoleOps::LoggingTypes::INFO_LOG,
+        ConsoleOps::LoggingTypes::DEBUG_LOG,
+        ConsoleOps::LoggingTypes::DEFAULT_LOG
+    };
+
+    for (size_t idx = 0; idx < enumsVec.size(); idx++)
+    {
+        EXPECT_EQ(enumsVec[idx], ConsoleOps::loggingTypesStringToEnum(enumStringsVec[idx]));
+        EXPECT_EQ(enumStringsVec[idx], ConsoleOps::loggingTypesEnumToString(enumsVec[idx]));
+    }
+}


### PR DESCRIPTION
A new class DataOps has been introduced to segregate the data operations from file operations from FileOps class.

As the data ops most probably going to be common both in FileOps class and ConsoleOps class thus now with inheritence mechanism we can now adhere to single responsiblity principle of so called SOLID principles.

Also the basic structure of Console related ops is intorduced.

And, obviously there are some cosmetic touch ups.