### PR TITLE
Check and print exceptions before getting destroyed

### DIFF
--- a/include/LoggingOps.hpp
+++ b/include/LoggingOps.hpp
@@ -122,7 +122,10 @@ class LoggingOps
 
         /**
          * @brief Destructor for LoggingOps class
-         * Stops the watcher thread and clears the data records queue
+         * Stops the watcher thread and clears the data records queue.
+         * 
+         * @note It also collects and prints any exceptions that occurred
+         * during the data operations before the object is destroyed.
          *
          * @note This function is thread safe. It uses mutex and condition variable
          * to ensure that only one thread can stop the watcher thread and clear the data records queue at a time.
@@ -415,6 +418,33 @@ class LoggingOps
          * during the data operations.
          */
         std::vector<std::exception_ptr> m_excpPtrVec;
+
+    private:
+        /**
+         * @brief Collect and print the exceptions occurred during the data operations
+         * This function will collect all the exceptions stored in the m_excpPtrVec (if any).
+         * It will then print them to a file named "LoggingExceptionsList.txt" 
+         * in the current working directory.
+         *
+         * @note This function is called at the end of the lifetime of the LoggingOps object
+         *       when the program is about to exit, or when the LoggingOps object is destroyed
+         *       to ensure that all the exceptions are logged before the program exits.
+         *
+         * @note This function is thread safe. It uses mutex to ensure that only one thread can collect and print the exceptions at a time.
+         */
+        void collectAndPrintExceptions();
+
+        /**
+         * @brief The name of the file where the exceptions will be logged
+         * It is a static constexpr string_view which is used to store the name of the file
+         * where the exceptions will be logged.
+         */
+        static constexpr std::string_view m_ExcpLogFileName = "LoggingExceptionsList.txt";
+        /**
+         * @brief The field separator used in the log file
+         * It is a static constexpr string_view which is used to separate the fields in the log file.
+         */
+        static constexpr std::string_view m_FieldSep = "|";
 };
 
 #endif  //LOGGING_OPS_HPP

--- a/src/FileOps.cpp
+++ b/src/FileOps.cpp
@@ -523,11 +523,13 @@ void FileOps::writeToOutStreamObject(BufferQ&& dataQueue, std::exception_ptr& ex
         m_isFileOpsRunning = true;
 
         std::ofstream file(m_FilePathObj, std::ios::out | std::ios::app | std::ios::binary);
+        std::array<char, bufferSize> data;
         if (file.is_open())
         {
             while (!dataQueue.empty())
             {
-                auto data = dataQueue.front();
+                data.fill('\0');
+                data = dataQueue.front();
                 dataQueue.pop();
                 file << data.data() << std::endl;
                 file.flush();
@@ -539,7 +541,8 @@ void FileOps::writeToOutStreamObject(BufferQ&& dataQueue, std::exception_ptr& ex
             std::ostringstream osstr;
             osstr << "WRITING_ERROR : [";
             osstr << std::this_thread::get_id();
-            osstr << "]: File [" << m_FilePathObj.string() << "] can not be opened to write data;";
+            osstr << "]: File [" << m_FilePathObj.string();
+            osstr << "] can not be opened to write log data: " << data.data() << "\n";
             errMsg = osstr.str();
         }
         m_isFileOpsRunning = false;


### PR DESCRIPTION
Before tthe object goes out of scope/destroyed it now checks if there is any exceptions caught during its lifetime and, if so, then print them one by one in a file for user's reference.