### PR TITLE
Bug fixing for class name and function names of the logged message

### DIFF
--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -310,11 +310,31 @@ namespace logger
             virtual void constructLogMsgPrefixSecondPart();
 
         private:
-            static const UNORD_STRING_MAP m_stringToEnumMap;
-            static const UNORD_LOG_TYPE_MAP m_EnumToStringMap;
+            /**
+             * @brief Extracts the class and function names from the function name.
+             * This function extracts the class name and function name from the
+             * full function name string, which may include a scope resolution operator (::).
+             *
+             * @param [out] className The extracted class name.
+             * @param [out] funcName The extracted function name.
+             */
+            void extractClassAndFuncName(std::string& className, std::string& funcName) noexcept;
 
+            /**
+             * @brief Logs a message with the specified format and arguments.
+             * This function formats the log message using the provided format string
+             * and arguments, and writes it to the log stream.
+             *
+             * @param [in] formatStr Format string for the log message.
+             * @param [in] args Arguments to be formatted into the log message.
+             * @note This function is used internally to handle the actual logging operation.
+             * It constructs the log message prefix and appends the formatted message
+             * to the log stream.
+             */
             void vlog(const std::string_view formatStr, std::format_args args);
 
+            static const UNORD_STRING_MAP m_stringToEnumMap;
+            static const UNORD_LOG_TYPE_MAP m_EnumToStringMap;
             std::thread::id m_threadID;
             Clock m_clock;
             size_t m_lineNo;

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -164,32 +164,21 @@ void Logger::populatePrerequisitFileds()
     // Clear the log stream before populating it with new log message
     std::stringstream().swap(m_logStream);
     constructLogMsgPrefix();
-    // Segregate the function name and class name from the
-    // m_funcName, if it is in the format "ClassName:FunctionName"
-    // If it is not in that format, then just use the function name
-    // as it is, without any class name.
-    // This is useful for logging purposes, to identify which class
-    // and function the log message is coming from.
-    // For example, if the function name is "Logger::log", then
-    // the class name will be "Logger" and the function name will be "log".
-    // If the function name is "log", then the class name will be empty
-    // and the function name will be "log".
-    // If the function name is "Logger::log()", then the class name will be "Logger"
-    // and the function name will be "log".
-    // If the function name is "Logger::log(const std::string&)", then the
-    // class name will be "Logger" and the function name will be "log".
     std::string funcName;
     std::string className;
-    if (std::string::npos != m_funcName.find(":"))
+    /* if (std::string::npos != m_funcName.find(":"))
     {
-        className = m_funcName.substr(0, m_funcName.find_first_of(":"));
-        funcName = m_funcName.substr(m_funcName.find_last_of(":") + 1);
+        className = m_funcName.substr(0, (m_funcName.find_first_of(":") - 1));
+        funcName = m_funcName.substr(m_funcName.find_first_of(":") + 2);
     }
     else
     {
         funcName = m_funcName;
     }
-    funcName = funcName.substr(0, funcName.find_first_of("("));
+    funcName = funcName.substr(0, funcName.find_first_of("(")); */
+
+    extractClassAndFuncName(className, funcName);
+
     m_logStream << LEFT_SQUARE_BRACE
                 << className
                 << ONE_SPACE
@@ -278,5 +267,36 @@ void Logger::vlog(const std::string_view formatStr, std::format_args args)
                     logMsg.find_last_of(DOUBLE_QUOTES) - 1);
     }
     m_logStream << logMsg;
+}
+
+void Logger::extractClassAndFuncName(std::string& className, std::string& funcName) noexcept
+{
+    className.clear();
+    funcName.clear();
+    if (m_funcName.empty())
+        return;
+
+    // Segregate the function name and class name from the
+    // m_funcName, if it is in the format "ClassName::FunctionName"
+    // If it is not in that format, then just use the function name
+    // as it is, without any class name.
+    // This is useful for logging purposes, to identify which class
+    // and function the log message is coming from.
+    // For example, if the function name is "Logger::log", then
+    // the class name will be "Logger" and the function name will be "log".
+    // If the function name is "log", then the class name will be empty
+    // and the function name will be "log".
+    // If the function name is "Logger::log()", then the class name will be "Logger"
+    // and the function name will be "log".
+    // If the function name is "Logger::log(const std::string&)", then the
+    // class name will be "Logger" and the function name will be "log".
+    funcName = m_funcName.substr(0, m_funcName.rfind("("));
+    auto scopeResOpertr = funcName.find_last_of("::");
+    if (std::string::npos != scopeResOpertr)
+    {
+        className = funcName.substr(0, (scopeResOpertr - 1));
+        funcName = funcName.substr(scopeResOpertr + 1);
+        className = className.substr(className.find_last_of(" ") + 1);
+    }
 }
 

--- a/tests/LoggerTest.cpp
+++ b/tests/LoggerTest.cpp
@@ -41,7 +41,7 @@ class LoggerTest : public CommonTestDataGenerator
         }
         void testLoggedData(
             const LOG_TYPE& expLogType,
-            const std::string_view funcName,
+            const std::string_view prettyFuncName,
             const std::string_view marker,
             const std::string_view logMsg = "")
         {
@@ -56,14 +56,14 @@ class LoggerTest : public CommonTestDataGenerator
                 << "oss.str() = " << oss.str() << ", " << "logStream.str() = " << logStream.str();
 
             EXPECT_TRUE(logStream.str().find(Logger::covertLogTypeEnumToString(expLogType)) != std::string::npos);
-
-            ASSERT_TRUE(std::string::npos != funcName.find(":"));
-            auto className = funcName.substr(0, funcName.find_first_of(":"));
-            auto funcNameWithoutClassName = funcName.substr(funcName.find_last_of(":") + 1);
+            ASSERT_TRUE(std::string::npos != prettyFuncName.find(":"));
+            auto className = prettyFuncName.substr(0, prettyFuncName.find_first_of(":"));
+            className = className.substr(className.rfind(" ") + 1);
+            auto funcNameWithoutClassName = prettyFuncName.substr(prettyFuncName.find_last_of(":") + 1);
             funcNameWithoutClassName = funcNameWithoutClassName.substr(0, funcNameWithoutClassName.find_first_of("("));
 
-            EXPECT_TRUE(logStream.str().find(className) != std::string::npos);
-            EXPECT_TRUE(logStream.str().find(funcNameWithoutClassName) != std::string::npos) << funcNameWithoutClassName;
+            EXPECT_TRUE(logStream.str().find(className) != std::string::npos) << "className = " << className << std::endl;
+            EXPECT_TRUE(logStream.str().find(funcNameWithoutClassName) != std::string::npos) << "funcNameWithoutClassName = " << funcNameWithoutClassName;
             EXPECT_TRUE(logStream.str().find(marker) != std::string::npos);
 
             if (!logMsg.empty())


### PR DESCRIPTION
During the use of this library in another application it has been observed that the there were some discrepancies in function name and class name for few cases in the generated log messages. These changes are aimed to fix those. Also the related test cases have been modified accordingly.